### PR TITLE
Update eyeglass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "name": "planifolia",
     "sassDir": "sass",
     "exports": false,
-    "needs": "^0.8.0"
+    "needs": "^1.0"
   },
   "keywords": [
     "sass",


### PR DESCRIPTION
This makes it possible to use with eyeglass 1.x.  Since 1.0.0 semver is used, so this should be safe.  Tested with latest eyeglass (1.2.1)