### PR TITLE
Fix deprecation warnings when using latest version of Dart Sass

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.6.1 (Unreleased as of 2022-05-02)
+------------------
+
+- fix deprecation warnings when using Dart Sass
+
 0.6.0 (2018-04-08)
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "sass-planifolia",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Vanilla Sass helper functions",
   "main": "index.js",
   "devDependencies": {
-    "mocha": "^9.2.0",
-    "node-sass": "^7.0.1",
-    "sassdoc": "^2.7.3"
+    "mocha": "^10.0.0",
+    "sass": "^1.51.0",
+    "sassdoc": "^2.7.4"
   },
   "scripts": {
     "test": "mocha",

--- a/sass/color.scss
+++ b/sass/color.scss
@@ -19,10 +19,13 @@
 ////
 
 /// @type string
+
+@use "sass:math";
+
 $planifolia-colorspace: 'lab' !default;
 
 @function _pf-perc($x) {
-  @return if(unit($x) == '%', $x / 100%, $x);
+  @return if(unit($x) == '%', math.div($x, 100%), $x);
 }
 
 @function _pf-clip-needed($rgb) {
@@ -37,21 +40,21 @@ $planifolia-colorspace: 'lab' !default;
 }
 
 @function _pf-srgb-to-rgb($c) {
-  $c: $c / 255;
+  $c: math.div($c, 255);
   @if $c <= 0.04045 {
-    $c: $c / 12.92;
+    $c: math.div($c, 12.92);
   } @else {
-    $c: pow(($c + 0.055) / 1.055, 2.4);
+    $c: pow(math.div($c + 0.055, 1.055), 2.4);
   }
   @return $c * 100;
 }
 
 @function _pf-rgb-to-srgb($c) {
-  $c: $c / 100;
+  $c: $c * 0.01;
   @if $c <= 0.0031308 {
     $c: $c * 12.92;
   } @else {
-    $c: 1.055 * pow($c, 1 / 2.4) - 0.055;
+    $c: 1.055 * pow($c, math.div(1, 2.4)) - 0.055;
   }
   @return $c * 255;
 }
@@ -105,19 +108,19 @@ $planifolia-colorspace: 'lab' !default;
 }
 
 @function _pf-xyz-to-lab-f($t) {
-  @if $t > 216 / 24389 {
-    @return pow($t, 1/3);
+  @if $t > math.div(216, 24389) {
+    @return pow($t, math.div(1, 3));
   } @else {
-    @return 841 / 108 * $t + 4 / 29;
+    @return math.div(841, 108) * $t + math.div(4, 29);
   }
 }
 
 @function _pf-xyz-to-lab($xyz) {
   $white: (95.05, 100, 108.9);
 
-  $x: _pf-xyz-to-lab-f(nth($xyz, 1) / nth($white, 1));
-  $y: _pf-xyz-to-lab-f(nth($xyz, 2) / nth($white, 2));
-  $z: _pf-xyz-to-lab-f(nth($xyz, 3) / nth($white, 3));
+  $x: _pf-xyz-to-lab-f(math.div(nth($xyz, 1), nth($white, 1)));
+  $y: _pf-xyz-to-lab-f(math.div(nth($xyz, 2), nth($white, 2)));
+  $z: _pf-xyz-to-lab-f(math.div(nth($xyz, 3), nth($white, 3)));
 
   $l: 116 * $y - 16;
   $a: 500 * ($x - $y);
@@ -127,29 +130,29 @@ $planifolia-colorspace: 'lab' !default;
 }
 
 @function _pf-lab-to-xyz-f($t) {
-  @if $t > 6 / 29 {
+  @if $t > math.div(6, 29) {
     @return pow($t, 3);
   } @else {
-    @return 108 / 841 * ($t - 4 / 29);
+    @return math.div(108, 841) * ($t - math.div(4, 29));
   }
 }
 
 @function _pf-lab-to-xyz($lab) {
   $white: (95.05, 100, 108.9);
 
-  $l: (nth($lab, 1) + 16) / 116;
+  $l: math.div(nth($lab, 1) + 16, 116);
 
-  $x: nth($white, 1) * _pf-lab-to-xyz-f($l + nth($lab, 2) / 500);
+  $x: nth($white, 1) * _pf-lab-to-xyz-f($l + math.div(nth($lab, 2), 500));
   $y: nth($white, 2) * _pf-lab-to-xyz-f($l);
-  $z: nth($white, 3) * _pf-lab-to-xyz-f($l - nth($lab, 3) / 200);
+  $z: nth($white, 3) * _pf-lab-to-xyz-f($l - math.div(nth($lab, 3), 200));
 
   @return ($x, $y, $z);
 }
 
 @function _pf-xyz-to-yuuvv($xyz) {
   $a: nth($xyz, 1) + 15 * nth($xyz, 2) + 3 * nth($xyz, 3);
-  $uu: if($a == 0, 0, 4 * nth($xyz, 1) / $a);
-  $vv: if($a == 0, 0, 9 * nth($xyz, 2) / $a);
+  $uu: if($a == 0, 0, math.div(4 * nth($xyz, 1), $a));
+  $vv: if($a == 0, 0, math.div(9 * nth($xyz, 2), $a));
   @return (nth($xyz, 2), $uu, $vv);
 }
 
@@ -158,8 +161,8 @@ $planifolia-colorspace: 'lab' !default;
   $uu: nth($yuuvv, 2);
   $vv: nth($yuuvv, 3);
 
-  $x: if($vv == 0, 0, $y * (9 * $uu) / (4 * $vv));
-  $z: if($vv == 0, 0, $y * (12 - 3 * $uu - 20 * $vv) / (4 * $vv));
+  $x: if($vv == 0, 0, math.div($y * (9 * $uu), 4 * $vv));
+  $z: if($vv == 0, 0, math.div($y * (12 - 3 * $uu - 20 * $vv), 4 * $vv));
 
   @return ($x, $y, $z);
 }
@@ -168,8 +171,8 @@ $planifolia-colorspace: 'lab' !default;
   $white: _pf-xyz-to-yuuvv((95.05, 100, 108.9));
   $yuuvv: _pf-xyz-to-yuuvv($xyz);
 
-  $y: nth($yuuvv, 1) / nth($white, 1);
-  $l: if($y > 216 / 24389, 116 * pow($y, 1 / 3) - 16, 24389 / 27 * $y);
+  $y: math.div(nth($yuuvv, 1), nth($white, 1));
+  $l: if($y > math.div(216, 24389), 116 * pow($y, math.div(1, 3)) - 16, math.div(24389, 27) * $y);
 
   $u: 13 * $l * (nth($yuuvv, 2) - nth($white, 2));
   $v: 13 * $l * (nth($yuuvv, 3) - nth($white, 3));
@@ -180,14 +183,14 @@ $planifolia-colorspace: 'lab' !default;
 @function _pf-luv-to-xyz($luv) {
   $white: _pf-xyz-to-yuuvv((95.05, 100, 108.9));
 
-  $uu: if(nth($luv, 1) == 0, 0, nth($luv, 2) / (13 * nth($luv, 1)) + nth($white, 2));
-  $vv: if(nth($luv, 1) == 0, 0, nth($luv, 3) / (13 * nth($luv, 1)) + nth($white, 3));
+  $uu: if(nth($luv, 1) == 0, 0, math.div(nth($luv, 2), 13 * nth($luv, 1)) + nth($white, 2));
+  $vv: if(nth($luv, 1) == 0, 0, math.div(nth($luv, 3), 13 * nth($luv, 1)) + nth($white, 3));
 
   $y: nth($white, 1);
   @if nth($luv, 1) > 8 {
-    $y: $y * pow((nth($luv, 1) + 16) / 116, 3);
+    $y: $y * pow(math.div(nth($luv, 1) + 16, 116), 3);
   } @else {
-    $y: $y * nth($luv, 1) * 27 / 24389;
+    $y: math.div($y * nth($luv, 1) * 27, 24389);
   }
 
   @return _pf-yuuvv-to-xyz(($y, $uu, $vv));
@@ -215,7 +218,7 @@ $planifolia-colorspace: 'lab' !default;
 @function _pf-max-chroma($lightness, $hue, $colorspace) {
   $c-min: 0;
   $c-max: 200;
-  $c-tmp: ($c-min + $c-max) / 2;
+  $c-tmp: ($c-min + $c-max) * 0.5;
 
   @while $c-max - $c-min > 1 {
     $rgb: _lch-unclipped($lightness, $c-tmp, $hue, $colorspace);
@@ -224,7 +227,7 @@ $planifolia-colorspace: 'lab' !default;
     } @else {
       $c-min: $c-tmp;
     }
-    $c-tmp: ($c-min + $c-max) / 2;
+    $c-tmp: ($c-min + $c-max) * 0.5;
   }
 
   @return $c-tmp;
@@ -241,7 +244,7 @@ $planifolia-colorspace: 'lab' !default;
   } @else if $colorspace == 'hslab' {
     $lch: _pf-to-lch($color, 'lab');
     $max: _pf-max-chroma(nth($lch, 1), nth($lch, 3), 'lab');
-    @return (nth($lch, 1), nth($lch, 2) / $max * 100, nth($lch, 3));
+    @return (nth($lch, 1), math.div(nth($lch, 2), $max) * 100, nth($lch, 3));
   } @else if $colorspace == 'luv' {
     $xyz: _pf-to-xyz($color);
     $luv: _pf-xyz-to-luv($xyz);
@@ -249,9 +252,9 @@ $planifolia-colorspace: 'lab' !default;
   } @else if $colorspace == 'hsluv' {
     $lch: _pf-to-lch($color, 'luv');
     $max: _pf-max-chroma(nth($lch, 1), nth($lch, 3), 'luv');
-    @return (nth($lch, 1), nth($lch, 2) / $max * 100, nth($lch, 3));
+    @return (nth($lch, 1), math.div(nth($lch, 2), $max) * 100, nth($lch, 3));
   } @else if $colorspace == 'hsl' {
-    @return (lightness($color) / 1%, saturation($color) / 1%, hue($color));
+    @return (math.div(lightness($color), 1%), math.div(saturation($color), 1%), hue($color));
   } @else if $colorspace == 'yuv' {
     $yuv: _pf-to-yuv($color);
     @return _pf-lab-to-lch($yuv);
@@ -267,16 +270,16 @@ $planifolia-colorspace: 'lab' !default;
     @return _pf-from-xyz($xyz);
   } @else if $colorspace == 'hslab' {
     $max: _pf-max-chroma($lightness, $hue, 'lab');
-    @return _lch-unclipped($lightness, $chroma * $max / 100, $hue, 'lab');
+    @return _lch-unclipped($lightness, $chroma * $max * 0.01, $hue, 'lab');
   } @else if $colorspace == 'luv' {
     $luv: _pf-lch-to-lab(($lightness, $chroma, $hue));
     $xyz: _pf-luv-to-xyz($luv);
     @return _pf-from-xyz($xyz);
   } @else if $colorspace == 'hsluv' {
     $max: _pf-max-chroma($lightness, $hue, 'luv');
-    @return _lch-unclipped($lightness, $chroma * $max / 100, $hue, 'luv');
+    @return _lch-unclipped($lightness, $chroma * $max * 0.01, $hue, 'luv');
   } @else if $colorspace == 'hsl' {
-    $color: hsl($hue / 1deg * 1deg, $chroma * 1%, $lightness * 1%);
+    $color: hsl(math.div($hue, 1deg) * 1deg, $chroma * 1%, $lightness * 1%);
     @return (red($color), green($color), blue($color));
   } @else if $colorspace == 'yuv' {
     $yuv: _pf-lch-to-lab(($lightness, $chroma, $hue));
@@ -307,7 +310,7 @@ $planifolia-colorspace: 'lab' !default;
   @if _pf-clip-needed($rgb) {
     $c-min: 0;
     $c-max: $chroma;
-    $c-tmp: ($c-min + $c-max) / 2;
+    $c-tmp: ($c-min + $c-max) * 0.5;
 
     @while $c-max - $c-min > 0.01 {
       $rgb: _lch-unclipped($lightness, $c-tmp, $hue, $colorspace);
@@ -316,7 +319,7 @@ $planifolia-colorspace: 'lab' !default;
       } @else {
         $c-min: $c-tmp;
       }
-      $c-tmp: ($c-min + $c-max) / 2;
+      $c-tmp: ($c-min + $c-max) * 0.5;
     }
   }
 
@@ -501,7 +504,7 @@ $planifolia-colorspace: 'lab' !default;
     $h1: $h1 + if($h1 < $h2, 360deg, -360deg);
   }
 
-  $h: ($h1 * $w1 + $h2 * $w2) / ($w1 + $w2);
+  $h: math.div($h1 * $w1 + $h2 * $w2, $w1 + $w2);
 
   @return ($l, $c, $h);
 }

--- a/sass/contrast.scss
+++ b/sass/contrast.scss
@@ -6,6 +6,9 @@
 ////
 
 /// @type color
+
+@use "sass:math";
+
 $planifolia-contrast-dark-default: black !default;
 /// @type color
 $planifolia-contrast-light-default: white !default;
@@ -36,9 +39,9 @@ $planifolia-srgb-lut: 0, 0.0003035269835488375, 0.000607053967097675, 0.00091058
   }
 
   $a: $a2 + (1 - $a2) * $a1;
-  $r: ($a2 * red($fg) + (1 - $a2) * $a1 * red($bg)) / $a;
-  $g: ($a2 * green($fg) + (1 - $a2) * $a1 * green($bg)) / $a;
-  $b: ($a2 * blue($fg) + (1 - $a2) * $a1 * blue($bg)) / $a;
+  $r: math.div($a2 * red($fg) + (1 - $a2) * $a1 * red($bg), $a);
+  $g: math.div($a2 * green($fg) + (1 - $a2) * $a1 * green($bg), $a);
+  $b: math.div($a2 * blue($fg) + (1 - $a2) * $a1 * blue($bg), $a);
 
   @return rgba($r, $g, $b, $a);
 }
@@ -54,7 +57,7 @@ $planifolia-srgb-lut: 0, 0.0003035269835488375, 0.000607053967097675, 0.00091058
 @function _pf-contrast($fg, $bg) {
   $lbg: luma($bg);
   $lfg: luma(alpha-blend($fg, $bg));
-  @return (max($lbg, $lfg) + 0.05) / (min($lbg, $lfg) + 0.05);
+  @return math.div(max($lbg, $lfg) + 0.05, min($lbg, $lfg) + 0.05);
 }
 
 /// Calculate the minimum possible contrast between two colors.
@@ -102,7 +105,7 @@ $planifolia-srgb-lut: 0, 0.0003035269835488375, 0.000607053967097675, 0.00091058
   } @else {
     $c1: contrast-min($color1, $color2);
     $c2: contrast-min($color2, $color1);
-    @return ($c1 + $c2) / 2;
+    @return ($c1 + $c2) * 0.5;
   }
 }
 

--- a/sass/grid.scss
+++ b/sass/grid.scss
@@ -55,6 +55,9 @@
 /// @prop {width} gutter [1rem] - Gutter width.
 /// @prop {width} gutter-fallback [2%] - Gutter width if `calc()` is
 ///   not available. Must be a percentage.
+
+@use "sass:math";
+
 $grid: (
   'columns': 12,
   'gutter': 1rem,
@@ -106,7 +109,7 @@ $grid: (
   $gutter: _grid-get('gutter', $settings);
   $gutter-fallback: _grid-get('gutter-fallback', $settings);
 
-  $w: $width / $columns;
+  $w: math.div($width, $columns);
 
   @if unit($gutter) == '%' {
     width: _grid-width($w, $gutter, $settings);
@@ -125,7 +128,7 @@ $grid: (
   $gutter: _grid-get('gutter', $settings);
   $gutter-fallback: _grid-get('gutter-fallback', $settings);
 
-  $p: $position / $columns;
+  $p: math.div($position, $columns);
 
   @if unit($gutter) == '%' {
     margin-left: _grid-position($p, $gutter, $settings);
@@ -162,7 +165,7 @@ $grid: (
 /// @param {map} $settings [()]
 @mixin grid-same-width($n, $settings: ()) {
   $columns: _grid-get('columns', $settings);
-  $width: $columns / $n;
+  $width: math.div($columns, $n);
 
   @include grid-cell($settings);
   @include grid-width($width, $settings);

--- a/sass/math.scss
+++ b/sass/math.scss
@@ -21,6 +21,9 @@
 ////
 
 /// @type number
+
+@use "sass:math";
+
 $planifolia-math-steps-default: 32 !default;
 
 /// @return {number}
@@ -29,7 +32,7 @@ $planifolia-math-steps-default: 32 !default;
 }
 
 @function _pf-angle-to-rad($x) {
-  @return (0rad + $x) / 1rad;
+  @return math.div(0rad + $x, 1rad);
 }
 
 @function _pf-exp-taylor-0($x, $steps) {
@@ -37,7 +40,7 @@ $planifolia-math-steps-default: 32 !default;
   $result: 1;
 
   @for $i from 1 to $steps {
-    $item: $item * $x / $i;
+    $item: math.div($item * $x, $i);
     $result: $result + $item;
   }
 
@@ -45,14 +48,14 @@ $planifolia-math-steps-default: 32 !default;
 }
 
 @function _pf-log-taylor-1($x, $steps) {
-  $z: ($x - 1) / ($x + 1);
+  $z: math.div($x - 1, $x + 1);
 
   $power: $z;
   $result: $z;
 
   @for $i from 1 to $steps {
     $power: $power * $z * $z;
-    $result: $result + $power / (2 * $i + 1);
+    $result: $result + math.div($power, 2 * $i + 1);
   }
 
   @return 2 * $result;
@@ -63,7 +66,7 @@ $planifolia-math-steps-default: 32 !default;
   $result: $x;
 
   @for $i from 1 to $steps {
-    $item: -$item * $x * $x / (2 * $i) / (2 * $i + 1);
+    $item: math.div(math.div(-$item * $x * $x, 2 * $i), 2 * $i + 1);
     $result: $result + $item;
   }
 
@@ -75,8 +78,8 @@ $planifolia-math-steps-default: 32 !default;
   $result: $x;
 
   @for $i from 1 to $steps {
-    $item: $item * $x * $x * (2 * $i - 1) / (2 * $i);
-    $result: $result + $item / (2 * $i + 1);
+    $item: math.div($item * $x * $x * (2 * $i - 1), 2 * $i);
+    $result: $result + math.div($item, 2 * $i + 1);
   }
 
   @return $result;
@@ -84,13 +87,13 @@ $planifolia-math-steps-default: 32 !default;
 
 @function _pf-pow-int($base, $exponent) {
   @if $exponent < 0 {
-    @return 1 / _pf-pow-int($base, -$exponent);
+    @return math.div(1, _pf-pow-int($base, -$exponent));
   } @else if $exponent == 0 {
     @return 1;
   } @else if $exponent == 1 {
     @return $base;
   } @else {
-    $exp: floor($exponent / 2);
+    $exp: floor($exponent * 0.5);
     $pow: _pf-pow-int($base, $exp);
     @if $exp * 2 == $exponent {
       @return $pow * $pow;
@@ -108,7 +111,7 @@ $planifolia-math-steps-default: 32 !default;
     // results in log().
     @return str-length(inspect(round($x))) - 1;
   } @else {
-    @return -1 * str-length(inspect(round(1 / $x)));
+    @return -1 * str-length(inspect(round(math.div(1, $x))));
   }
 }
 
@@ -119,7 +122,7 @@ $planifolia-math-steps-default: 32 !default;
   $log10: 2.302585092994046;
   $approx: _pf-log10-approx($x);
   // $y is in range [1, 10]
-  $y: $x / _pf-pow-int(10, $approx);
+  $y: math.div($x, _pf-pow-int(10, $approx));
   @return $approx * $log10 + _pf-log-taylor-1($y, $steps);
 }
 
@@ -128,7 +131,7 @@ $planifolia-math-steps-default: 32 !default;
 /// @return {number}
 @function log10($x, $steps: $planifolia-math-steps-default) {
   $log10: 2.302585092994046;
-  @return log($x, $steps) / $log10;
+  @return math.div(log($x, $steps), $log10);
 }
 
 /// @param {number} $x
@@ -156,7 +159,7 @@ $planifolia-math-steps-default: 32 !default;
 /// @param {number} $steps [32] - steps of the taylor expansion
 /// @return {number}
 @function nth-root($x, $exponent, $steps: $planifolia-math-steps-default) {
-  @return pow($x, 1 / $exponent, $steps);
+  @return pow($x, math.div(1, $exponent), $steps);
 }
 
 /// @param {number} $x
@@ -189,14 +192,14 @@ $planifolia-math-steps-default: 32 !default;
 /// @return {number}
 @function cos($x, $steps: $planifolia-math-steps-default) {
   $x: _pf-angle-to-rad($x);
-  @return sin($x + pi() / 2, $steps);
+  @return sin($x + pi() * 0.5, $steps);
 }
 
 /// @param {number} $x
 /// @param {number} $steps [32] - steps of the taylor expansion
 /// @return {number}
 @function tan($x, $steps: $planifolia-math-steps-default) {
-  @return sin($x, $steps) / cos($x, $steps);
+  @return math.div(sin($x, $steps), cos($x, $steps));
 }
 
 /// @param {number} $x
@@ -216,7 +219,7 @@ $planifolia-math-steps-default: 32 !default;
 /// @param {number} $steps [32] - steps of the taylor expansion
 /// @return {number}
 @function acos($x, $steps: $planifolia-math-steps-default) {
-  @return pi() / 2 - asin($x, $steps);
+  @return pi() * 0.5 - asin($x, $steps);
 }
 
 /// @param {number} $x
@@ -228,7 +231,7 @@ $planifolia-math-steps-default: 32 !default;
   } @else if $x < 0 {
     @return -1 * atan(-$x, $steps);
   } @else {
-    @return asin(1 / sqrt(1 + 1 / ($x * $x), $steps), $steps);
+    @return asin(math.div(1, sqrt(1 + math.div(1, $x * $x), $steps)), $steps);
   }
 }
 
@@ -239,18 +242,18 @@ $planifolia-math-steps-default: 32 !default;
 /// @return {number}
 @function atan2($y, $x, $steps: $planifolia-math-steps-default) {
   @if $x > 0 {
-    @return atan($y / $x, $steps);
+    @return atan(math.div($y, $x), $steps);
   } @else if $x < 0 {
     @if $y >= 0 {
-      @return atan($y / $x, $steps) + pi();
+      @return atan(math.div($y, $x), $steps) + pi();
     } @else {
-      @return atan($y / $x, $steps) - pi();
+      @return atan(math.div($y, $x), $steps) - pi();
     }
   } @else {
     @if $y > 0 {
-      @return pi() / 2;
+      @return pi() * 0.5;
     } @else if $y < 0 {
-      @return pi() / -2;
+      @return math.div(pi(), -2);
     } @else {
       @return 0;
     }

--- a/test/color.js
+++ b/test/color.js
@@ -7,13 +7,13 @@ describe('color', function() {
   describe('lab', function() {
     describe('lch', function() {
       it('white', function() {
-        assert.equal(renderer.value('lch(100, 0, 0rad)'), 'white')
+        assert.equal(renderer.value('lch(100, 0, 0rad)'), '#fff')
       });
       it('black', function() {
-        assert.equal(renderer.value('lch(0, 0, 0rad)'), 'black')
+        assert.equal(renderer.value('lch(0, 0, 0rad)'), '#000')
       });
       it('red (rad)', function() {
-        assert.equal(renderer.value('lch(53.23288, 104.57421, 0.69818rad)'), 'red')
+        assert.equal(renderer.value('lch(53.23288, 104.57421, .69818rad)'), 'red')
       });
       it('red (deg)', function() {
         assert.equal(renderer.value('lch(53.23288, 104.57421, 40deg)'), 'red')
@@ -43,7 +43,7 @@ describe('color', function() {
 
     describe('pf-chroma', function() {
       it('white', function() {
-        shared.similar(renderer.value('pf-chroma(white)'), 0, 0.0001);
+        shared.similar(renderer.value('pf-chroma(white)'), 0, .0001);
       });
       it('black', function() {
         shared.similar(renderer.value('pf-chroma(black)'), 0);
@@ -79,7 +79,7 @@ describe('color', function() {
 
     describe('pf-complement', function() {
       it('white', function() {
-        assert.equal(renderer.value('pf-complement(white)'), 'white')
+        assert.equal(renderer.value('pf-complement(white)'), '#fff')
       });
       it('red', function() {
         assert.equal(renderer.value('pf-complement(red)'), '#008ca1')
@@ -112,22 +112,22 @@ describe('color', function() {
 
     describe('pf-mix', function() {
       it('white, white', function() {
-        assert.equal(renderer.value('pf-mix(white, white)'), 'white')
+        assert.equal(renderer.value('pf-mix(white, white)'), '#fff')
       });
       it('black, white', function() {
-        assert.equal(renderer.value('pf-mix(black, white)'), '#777777')
+        assert.equal(renderer.value('pf-mix(black, white)'), '#777')
       });
       it('black, white, 0%', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 0%)'), 'white')
+        assert.equal(renderer.value('pf-mix(black, white, 0%)'), '#fff')
       });
       it('black, white, 100%', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 100%)'), 'black')
+        assert.equal(renderer.value('pf-mix(black, white, 100%)'), '#000')
       });
       it('black, white, 20%', function() {
         assert.equal(renderer.value('pf-mix(black, white, 20%)'), '#c6c6c6')
       });
-      it('black, white, 0.2', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 0.2)'), '#c6c6c6')
+      it('black, white, .2', function() {
+        assert.equal(renderer.value('pf-mix(black, white, .2)'), '#c6c6c6')
       });
       it('blue, red', function() {
         assert.equal(renderer.value('pf-mix(blue, red)'), '#c20081')
@@ -153,13 +153,13 @@ describe('color', function() {
   describe('luv', function() {
     describe('lch', function() {
       it('white', function() {
-        assert.equal(renderer.value('lch(100, 0, 0rad, "luv")'), 'white')
+        assert.equal(renderer.value('lch(100, 0, 0rad, "luv")'), '#fff')
       });
       it('black', function() {
-        assert.equal(renderer.value('lch(0, 0, 0rad, "luv")'), 'black')
+        assert.equal(renderer.value('lch(0, 0, 0rad, "luv")'), '#000')
       });
       it('red (rad)', function() {
-        assert.equal(renderer.value('lch(53.23288, 179.07872, 0.21245rad, "luv")'), 'red')
+        assert.equal(renderer.value('lch(53.23288, 179.07872, .21245rad, "luv")'), 'red')
       });
       it('red (deg)', function() {
         assert.equal(renderer.value('lch(53.23288, 179.07872, 12.1725deg, "luv")'), 'red')
@@ -189,7 +189,7 @@ describe('color', function() {
 
     describe('pf-chroma', function() {
       it('white', function() {
-        shared.similar(renderer.value('pf-chroma(white, "luv")'), 0, 0.0001);
+        shared.similar(renderer.value('pf-chroma(white, "luv")'), 0, .0001);
       });
       it('black', function() {
         shared.similar(renderer.value('pf-chroma(black, "luv")'), 0);
@@ -225,7 +225,7 @@ describe('color', function() {
 
     describe('pf-complement', function() {
       it('white', function() {
-        assert.equal(renderer.value('pf-complement(white, "luv")'), 'white')
+        assert.equal(renderer.value('pf-complement(white, "luv")'), '#fff')
       });
       it('red', function() {
         assert.equal(renderer.value('pf-complement(red, "luv")'), '#008e8e')
@@ -237,22 +237,22 @@ describe('color', function() {
 
     describe('pf-mix', function() {
       it('white, white', function() {
-        assert.equal(renderer.value('pf-mix(white, white, 50%, "luv")'), 'white')
+        assert.equal(renderer.value('pf-mix(white, white, 50%, "luv")'), '#fff')
       });
       it('black, white', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 50%, "luv")'), '#777777')
+        assert.equal(renderer.value('pf-mix(black, white, 50%, "luv")'), '#777')
       });
       it('black, white, 0%', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 0%, "luv")'), 'white')
+        assert.equal(renderer.value('pf-mix(black, white, 0%, "luv")'), '#fff')
       });
       it('black, white, 100%', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 100%, "luv")'), 'black')
+        assert.equal(renderer.value('pf-mix(black, white, 100%, "luv")'), '#000')
       });
       it('black, white, 20%', function() {
         assert.equal(renderer.value('pf-mix(black, white, 20%, "luv")'), '#c6c6c6')
       });
-      it('black, white, 0.2', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 0.2, "luv")'), '#c6c6c6')
+      it('black, white, .2', function() {
+        assert.equal(renderer.value('pf-mix(black, white, .2, "luv")'), '#c6c6c6')
       });
       it('blue, red', function() {
         assert.equal(renderer.value('pf-mix(blue, red, 50%, "luv")'), '#bd0095')
@@ -278,10 +278,10 @@ describe('color', function() {
   describe('hsl', function() {
     describe('lch', function() {
       it('white', function() {
-        assert.equal(renderer.value('lch(100, 0, 0rad, "hsl")'), 'white')
+        assert.equal(renderer.value('lch(100, 0, 0rad, "hsl")'), '#fff')
       });
       it('black', function() {
-        assert.equal(renderer.value('lch(0, 0, 0rad, "hsl")'), 'black')
+        assert.equal(renderer.value('lch(0, 0, 0rad, "hsl")'), '#000')
       });
       it('red', function() {
         assert.equal(renderer.value('lch(50, 100, 0rad, "hsl")'), 'red')
@@ -350,10 +350,10 @@ describe('color', function() {
 
     describe('pf-complement', function() {
       it('white', function() {
-        assert.equal(renderer.value('pf-complement(white, "hsl")'), 'white')
+        assert.equal(renderer.value('pf-complement(white, "hsl")'), '#fff')
       });
       it('red', function() {
-        assert.equal(renderer.value('pf-complement(red, "hsl")'), 'cyan')
+        assert.equal(renderer.value('pf-complement(red, "hsl")'), 'aqua')
       });
       it('yellow', function() {
         assert.equal(renderer.value('pf-complement(yellow, "hsl")'), 'blue')
@@ -362,19 +362,19 @@ describe('color', function() {
 
     describe('pf-mix', function() {
       it('white, white', function() {
-        assert.equal(renderer.value('pf-mix(white, white, 50%, "hsl")'), 'white')
+        assert.equal(renderer.value('pf-mix(white, white, 50%, "hsl")'), '#fff')
       });
       it('black, white', function() {
         assert.equal(renderer.value('pf-mix(black, white, 50%, "hsl")'), 'gray')
       });
       it('black, white, 0%', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 0%, "hsl")'), 'white')
+        assert.equal(renderer.value('pf-mix(black, white, 0%, "hsl")'), '#fff')
       });
       it('black, white, 100%', function() {
-        assert.equal(renderer.value('pf-mix(black, white, 100%, "hsl")'), 'black')
+        assert.equal(renderer.value('pf-mix(black, white, 100%, "hsl")'), '#000')
       });
       it('blue, red', function() {
-        assert.equal(renderer.value('pf-mix(blue, red, 50%, "hsl")'), 'magenta')
+        assert.equal(renderer.value('pf-mix(blue, red, 50%, "hsl")'), '#f0f')
       });
       it('yellow, blue', function() {
         assert.equal(renderer.value('pf-mix(yellow, blue, 50%, "hsl")'), '#00ff80')

--- a/test/contrast.js
+++ b/test/contrast.js
@@ -6,33 +6,33 @@ describe('contrast', function() {
 
   describe('alpha-blend', function() {
     it('fully opaque', function() {
-      assert.equal(renderer.value('alpha-blend(white)'), 'white')
-      assert.equal(renderer.value('alpha-blend(black)'), 'black')
+      assert.equal(renderer.value('alpha-blend(white)'), '#fff')
+      assert.equal(renderer.value('alpha-blend(black)'), '#000')
       assert.equal(renderer.value('alpha-blend(red)'), 'red')
     });
     it('fully transparent', function() {
       assert.equal(renderer.value('alpha-blend(rgba(white, 0), blue)'), 'blue')
       assert.equal(renderer.value('alpha-blend(rgba(black, 0), blue)'), 'blue')
       assert.equal(renderer.value('alpha-blend(rgba(red, 0), blue)'), 'blue')
-      assert.equal(renderer.value('alpha-blend(rgba(blue, 0))'), 'white')
+      assert.equal(renderer.value('alpha-blend(rgba(blue, 0))'), '#fff')
     });
     it('50%', function() {
-      assert.equal(renderer.value('alpha-blend(rgba(white, 0.5), blue)'), '#8080ff')
-      assert.equal(renderer.value('alpha-blend(rgba(black, 0.5), blue)'), 'navy')
-      assert.equal(renderer.value('alpha-blend(rgba(red, 0.5), blue)'), 'purple')
-      assert.equal(renderer.value('alpha-blend(rgba(blue, 0.5))'), '#8080ff')
+      assert.equal(renderer.value('alpha-blend(rgba(white, .5), blue)'), '#8080ff')
+      assert.equal(renderer.value('alpha-blend(rgba(black, .5), blue)'), 'navy')
+      assert.equal(renderer.value('alpha-blend(rgba(red, .5), blue)'), 'purple')
+      assert.equal(renderer.value('alpha-blend(rgba(blue, .5))'), '#8080ff')
     });
     it('13%', function() {
-      assert.equal(renderer.value('alpha-blend(rgba(white, 0.13), blue)'), '#2121ff')
-      assert.equal(renderer.value('alpha-blend(rgba(black, 0.13), blue)'), '#0000de')
-      assert.equal(renderer.value('alpha-blend(rgba(red, 0.13), blue)'), '#2100de')
-      assert.equal(renderer.value('alpha-blend(rgba(blue, 0.13))'), '#dedeff')
+      assert.equal(renderer.value('alpha-blend(rgba(white, .13), blue)'), '#2121ff')
+      assert.equal(renderer.value('alpha-blend(rgba(black, .13), blue)'), '#0000de')
+      assert.equal(renderer.value('alpha-blend(rgba(red, .13), blue)'), '#2100de')
+      assert.equal(renderer.value('alpha-blend(rgba(blue, .13))'), '#dedeff')
     });
     it('transparent background', function() {
-      assert.equal(renderer.value('alpha-blend(rgba(white, 0.5), rgba(blue, 0.5))'), 'rgba(170, 170, 255, 0.75)')
+      assert.equal(renderer.value('alpha-blend(rgba(white, .5), rgba(blue, .5))'), 'rgba(170,170,255,.75)')
     });
     it('both fully transparent', function() {
-      assert.equal(renderer.value('alpha-blend(rgba(white, 0), rgba(black, 0))'), 'rgba(255, 255, 255, 0)')
+      assert.equal(renderer.value('alpha-blend(rgba(white, 0), rgba(black, 0))'), 'rgba(255,255,255,0)')
     });
   });
 
@@ -44,28 +44,28 @@ describe('contrast', function() {
       assert.equal(renderer.value('luma(black)'), '0')
     });
     it('red', function() {
-      assert.equal(renderer.value('luma(#f00)'), '0.2126')
+      assert.equal(renderer.value('luma(#f00)'), '.2126')
     });
     it('green', function() {
-      assert.equal(renderer.value('luma(#0f0)'), '0.7152')
+      assert.equal(renderer.value('luma(#0f0)'), '.7152')
     });
     it('blue', function() {
-      assert.equal(renderer.value('luma(#00f)'), '0.0722')
+      assert.equal(renderer.value('luma(#00f)'), '.0722')
     });
     it('yellow', function() {
-      assert.equal(renderer.value('luma(yellow)'), '0.9278')
+      assert.equal(renderer.value('luma(yellow)'), '.9278')
     });
     it('cyan', function() {
-      assert.equal(renderer.value('luma(cyan)'), '0.7874')
+      assert.equal(renderer.value('luma(cyan)'), '.7874')
     });
     it('random', function() {
-      shared.similar(renderer.value('luma(rgb(12, 180, 92))'), 0.3349, 0.02);
+      shared.similar(renderer.value('luma(rgb(12, 180, 92))'), .3349, .02);
     });
     it('white with alpha', function() {
-      assert.equal(renderer.value('luma(rgba(255,255,255,0.5))'), '1')
+      assert.equal(renderer.value('luma(rgba(255,255,255,.5))'), '1')
     });
     it('black with alpha', function() {
-      assert.equal(renderer.value('luma(rgba(0,0,0,0.5))'), '0')
+      assert.equal(renderer.value('luma(rgba(0,0,0,.5))'), '0')
     });
   });
 
@@ -83,31 +83,31 @@ describe('contrast', function() {
       assert.equal(renderer.value('contrast(red, red)'), '1')
     });
     it('red-lightblue', function() {
-      shared.similar(renderer.value('contrast(red, #676eff)'), 1, 0.02);
+      shared.similar(renderer.value('contrast(red, #676eff)'), 1, .02);
     });
   });
 
   describe('contrast-color', function() {
     it('white', function() {
-      assert.equal(renderer.value('contrast-color(white)'), 'black')
+      assert.equal(renderer.value('contrast-color(white)'), '#000')
     });
     it('black', function() {
-      assert.equal(renderer.value('contrast-color(black)'), 'white')
+      assert.equal(renderer.value('contrast-color(black)'), '#fff')
     });
     it('red', function() {
-      assert.equal(renderer.value('contrast-color(#f00)'), 'black')
+      assert.equal(renderer.value('contrast-color(#f00)'), '#000')
     });
     it('green', function() {
-      assert.equal(renderer.value('contrast-color(#0f0)'), 'black')
+      assert.equal(renderer.value('contrast-color(#0f0)'), '#000')
     });
     it('blue', function() {
-      assert.equal(renderer.value('contrast-color(#00f)'), 'white')
+      assert.equal(renderer.value('contrast-color(#00f)'), '#fff')
     });
     it('yellow', function() {
-      assert.equal(renderer.value('contrast-color(yellow)'), 'black')
+      assert.equal(renderer.value('contrast-color(yellow)'), '#000')
     });
     it('cyan', function() {
-      assert.equal(renderer.value('contrast-color(cyan)'), 'black')
+      assert.equal(renderer.value('contrast-color(cyan)'), '#000')
     });
     it('light', function() {
       assert.equal(renderer.value('contrast-color(white, #111, #eee)'), '#111')
@@ -125,19 +125,19 @@ describe('contrast', function() {
 
   describe('contrast-stretch', function() {
     it('white-black', function() {
-      assert.equal(renderer.value('contrast-stretch(white, black)'), 'black')
+      assert.equal(renderer.value('contrast-stretch(white, black)'), '#000')
     });
     it('white-#333', function() {
       assert.equal(renderer.value('contrast-stretch(white, #333)'), '#333')
     });
     it('white-#333-21', function() {
-      assert.equal(renderer.value('contrast-stretch(white, #333, 21)'), 'black')
+      assert.equal(renderer.value('contrast-stretch(white, #333, 21)'), '#000')
     });
     it('#333-blue-7', function() {
-      assert.equal(renderer.value('contrast-stretch(#333, blue, 7)'), '#bbbbff')
+      assert.equal(renderer.value('contrast-stretch(#333, blue, 7)'), '#bbf')
     });
     it('#333-blue-AAA', function() {
-      assert.equal(renderer.value('contrast-stretch(#333, blue, "AAA")'), '#bbbbff')
+      assert.equal(renderer.value('contrast-stretch(#333, blue, "AAA")'), '#bbf')
     });
   });
 });

--- a/test/grid.js
+++ b/test/grid.js
@@ -16,7 +16,7 @@ describe('grid', function() {
   describe('grid-width', function() {
     it('uses calc() for output', function() {
       var call = renderer.block('@include grid-width(1)')
-      shared.declares(call, 'width', 'calc((100% + 1rem) * 0.08333 - 1rem)');
+      shared.declares(call, 'width', 'calc((100% + 1rem) * 0.0833333333 - 1rem)');
     });
     it('provides a fallback', function() {
       var call = renderer.block('@include grid-width(1)')
@@ -24,17 +24,17 @@ describe('grid', function() {
     });
     it('grid-width(2)', function() {
       var call = renderer.block('@include grid-width(2)')
-      shared.declares(call, 'width', 'calc((100% + 1rem) * 0.16667 - 1rem)');
+      shared.declares(call, 'width', 'calc((100% + 1rem) * 0.1666666667 - 1rem)');
       shared.declares(call, 'width', '15%');
     });
     it('uses gutter setting', function() {
       var call = renderer.block('@include grid-width(1, (gutter: 2em))')
-      shared.declares(call, 'width', 'calc((100% + 2em) * 0.08333 - 2em)');
+      shared.declares(call, 'width', 'calc((100% + 2em) * 0.0833333333 - 2em)');
       shared.declares(call, 'width', '6.5%');
     });
     it('uses gutter-fallback setting', function() {
       var call = renderer.block('@include grid-width(1, (gutter-fallback: 8%))')
-      shared.declares(call, 'width', 'calc((100% + 1rem) * 0.08333 - 1rem)');
+      shared.declares(call, 'width', 'calc((100% + 1rem) * 0.0833333333 - 1rem)');
       shared.declares(call, 'width', '1%');
     });
     it('uses columns setting', function() {
@@ -47,7 +47,7 @@ describe('grid', function() {
   describe('grid-position', function() {
     it('uses calc() for output', function() {
       var call = renderer.block('@include grid-position(1)')
-      shared.declares(call, 'margin-left', 'calc((100% + 1rem) * 0.08333)');
+      shared.declares(call, 'margin-left', 'calc((100% + 1rem) * 0.0833333333)');
     });
     it('provides a fallback', function() {
       var call = renderer.block('@include grid-position(1)')
@@ -55,17 +55,17 @@ describe('grid', function() {
     });
     it('grid-position(2)', function() {
       var call = renderer.block('@include grid-position(2)')
-      shared.declares(call, 'margin-left', 'calc((100% + 1rem) * 0.16667)');
+      shared.declares(call, 'margin-left', 'calc((100% + 1rem) * 0.1666666667)');
       shared.declares(call, 'margin-left', '17%');
     });
     it('uses gutter setting', function() {
       var call = renderer.block('@include grid-position(1, (gutter: 2em))')
-      shared.declares(call, 'margin-left', 'calc((100% + 2em) * 0.08333)');
+      shared.declares(call, 'margin-left', 'calc((100% + 2em) * 0.0833333333)');
       shared.declares(call, 'margin-left', '8.5%');
     });
     it('uses gutter-fallback setting', function() {
       var call = renderer.block('@include grid-position(1, (gutter-fallback: 8%))')
-      shared.declares(call, 'margin-left', 'calc((100% + 1rem) * 0.08333)');
+      shared.declares(call, 'margin-left', 'calc((100% + 1rem) * 0.0833333333)');
       shared.declares(call, 'margin-left', '9%');
     });
     it('uses columns setting', function() {

--- a/test/math.js
+++ b/test/math.js
@@ -2,20 +2,20 @@ var assert = require('assert');
 var shared = require('./shared');
 
 describe('math', function() {
-  var renderer = new shared.Renderer('@import "math";');
+  var renderer = new shared.Renderer('@use "sass:math";@import "math";');
 
   describe('pow', function() {
     it('pow(3, 2) == 9', function() {
       assert.strictEqual(renderer.value('pow(3, 2)'), '9')
     });
-    it('pow(4, 3/2) == 8', function() {
-      assert.strictEqual(renderer.value('pow(4, 3/2)'), '8')
+    it('pow(4, math.div(3, 2)) == 8', function() {
+      assert.strictEqual(renderer.value('pow(4, math.div(3, 2))'), '8')
     });
-    it('pow(144, 1/2) == 12', function() {
-      assert.strictEqual(renderer.value('pow(144, 1/2)'), '12')
+    it('pow(144, math.div(1, 2)) == 12', function() {
+      assert.strictEqual(renderer.value('pow(144, math.div(1, 2))'), '12')
     });
-    it('pow(0, 1/2) == 0', function() {
-      assert.strictEqual(renderer.value('pow(0, 1/2)'), '0')
+    it('pow(0, math.div(1, 2)) == 0', function() {
+      assert.strictEqual(renderer.value('pow(0, math.div(1, 2))'), '0')
     });
     it('pow(-3, 2) == 9', function() {
       assert.strictEqual(renderer.value('pow(-3, 2)'), '9')
@@ -26,14 +26,14 @@ describe('math', function() {
     it('pow(3, -2)', function() {
       shared.similar(renderer.value('pow(3, -2)'), Math.pow(3, -2));
     });
-    it('pow(64, -1/2) == 0.125', function() {
-      assert.strictEqual(renderer.value('pow(64, -1/2)'), '0.125')
+    it('pow(64, math.div(-1, 2)) == .125', function() {
+      assert.strictEqual(renderer.value('pow(64, math.div(-1, 2))'), '.125')
     });
     it('pow(1200, 3.4)', function() {
-      shared.similar(renderer.value('pow(1200, 3.4)'), Math.pow(1200, 3.4), 0.1);
+      shared.similar(renderer.value('pow(1200, 3.4)'), Math.pow(1200, 3.4), .1);
     });
     it('pow(1200.3, 3.4)', function() {
-      shared.similar(renderer.value('pow(1200.3, 3.4)'), Math.pow(1200.3, 3.4), 0.1);
+      shared.similar(renderer.value('pow(1200.3, 3.4)'), Math.pow(1200.3, 3.4), .1);
     });
     it('pow(3px, 2.4) throws', function() {
       assert.throws(function () {
@@ -55,8 +55,8 @@ describe('math', function() {
     it('log(1) == 0', function() {
       assert.strictEqual(renderer.value('log(1)'), '0')
     });
-    it('log(0.1)', function() {
-      shared.similar(renderer.value('log(0.1)'), Math.log(0.1));
+    it('log(.1)', function() {
+      shared.similar(renderer.value('log(.1)'), Math.log(.1));
     });
     it('log(123456789)', function() {
       shared.similar(renderer.value('log(123456789)'), Math.log(123456789));
@@ -82,11 +82,11 @@ describe('math', function() {
     it('sin(-1 * pi()) == 0', function() {
       assert.strictEqual(renderer.value('sin(-1 * pi())'), '0');
     });
-    it('sin(1/2 * pi()) == 1', function() {
-      assert.strictEqual(renderer.value('sin(1/2 * pi())'), '1');
+    it('sin(math.div(1, 2) * pi()) == 1', function() {
+      assert.strictEqual(renderer.value('sin(math.div(1, 2) * pi())'), '1');
     });
-    it('sin(3/2 * pi()) == -1', function() {
-      assert.strictEqual(renderer.value('sin(3/2 * pi())'), '-1');
+    it('sin(math.div(3, 2) * pi()) == -1', function() {
+      assert.strictEqual(renderer.value('sin(math.div(3, 2) * pi())'), '-1');
     });
     it('sin(1)', function() {
       shared.similar(renderer.value('sin(1)'), Math.sin(1));
@@ -139,20 +139,20 @@ describe('math', function() {
     it('asin(0) == 0', function() {
       assert.strictEqual(renderer.value('asin(0)'), '0')
     });
-    it('asin(0.1)', function() {
-      shared.similar(renderer.value('asin(0.1)'), Math.asin(0.1));
+    it('asin(.1)', function() {
+      shared.similar(renderer.value('asin(.1)'), Math.asin(.1));
     });
-    it('asin(0.5)', function() {
-      shared.similar(renderer.value('asin(0.5)'), Math.asin(0.5));
+    it('asin(.5)', function() {
+      shared.similar(renderer.value('asin(.5)'), Math.asin(.5));
     });
-    it('asin(0.9)', function() {
-      shared.similar(renderer.value('asin(0.9)'), Math.asin(0.9));
+    it('asin(.9)', function() {
+      shared.similar(renderer.value('asin(.9)'), Math.asin(.9));
     });
     it('asin(1)', function() {
       shared.similar(renderer.value('asin(1)'), Math.asin(1));
     });
-    it('asin(-0.5)', function() {
-      shared.similar(renderer.value('asin(-0.5)'), Math.asin(-0.5));
+    it('asin(-.5)', function() {
+      shared.similar(renderer.value('asin(-.5)'), Math.asin(-.5));
     });
     it('asin(2) throws', function() {
       assert.throws(function () {
@@ -165,11 +165,11 @@ describe('math', function() {
     it('acos(1) == 0', function() {
       assert.strictEqual(renderer.value('acos(1)'), '0')
     });
-    it('acos(0.5)', function() {
-      shared.similar(renderer.value('acos(0.5)'), Math.acos(0.5));
+    it('acos(.5)', function() {
+      shared.similar(renderer.value('acos(.5)'), Math.acos(.5));
     });
-    it('acos(-0.5)', function() {
-      shared.similar(renderer.value('acos(-0.5)'), Math.acos(-0.5));
+    it('acos(-.5)', function() {
+      shared.similar(renderer.value('acos(-.5)'), Math.acos(-.5));
     });
     it('acos(2) throws', function() {
       assert.throws(function () {
@@ -182,11 +182,11 @@ describe('math', function() {
     it('atan(0) == 0', function() {
       assert.strictEqual(renderer.value('atan(0)'), '0')
     });
-    it('atan(0.5)', function() {
-      shared.similar(renderer.value('atan(0.5)'), Math.atan(0.5));
+    it('atan(.5)', function() {
+      shared.similar(renderer.value('atan(.5)'), Math.atan(.5));
     });
-    it('atan(-0.5)', function() {
-      shared.similar(renderer.value('atan(-0.5)'), Math.atan(-0.5));
+    it('atan(-.5)', function() {
+      shared.similar(renderer.value('atan(-.5)'), Math.atan(-.5));
     });
     it('atan(12345678.9)', function() {
       shared.similar(renderer.value('atan(12345678.9)'), Math.atan(12345678.9));
@@ -215,23 +215,23 @@ describe('math', function() {
   });
 
   describe('bezier', function() {
-    it('bezier((0 0, 1 1), 0.5) == 0.5 0.5', function() {
-      assert.strictEqual(renderer.value('bezier((0 0, 1 1), 0.5)'), '0.5 0.5');
+    it('bezier((0 0, 1 1), .5) == .5 .5', function() {
+      assert.strictEqual(renderer.value('bezier((0 0, 1 1), .5)'), '.5 .5');
     });
-    it('bezier((0 0, 0.2 0.2, 1 1), 0.5) == 0.35 0.35', function() {
-      assert.strictEqual(renderer.value('bezier((0 0, 0.2 0.2, 1 1), 0.5)'), '0.35 0.35');
+    it('bezier((0 0, .2 .2, 1 1), .5) == .35 .35', function() {
+      assert.strictEqual(renderer.value('bezier((0 0, .2 .2, 1 1), .5)'), '.35 .35');
     });
-    it('bezier((0 0, 0.5 0.2, 1 1), 0.5) == 0.5 0.35', function() {
-      assert.strictEqual(renderer.value('bezier((0 0, 0.5 0.2, 1 1), 0.5)'), '0.5 0.35');
+    it('bezier((0 0, .5 .2, 1 1), .5) == .5 .35', function() {
+      assert.strictEqual(renderer.value('bezier((0 0, .5 .2, 1 1), .5)'), '.5 .35');
     });
-    it('bezier((0, 1), 0.5) == 0.5', function() {
-      assert.strictEqual(renderer.value('bezier((0, 1), 0.5)'), '0.5');
+    it('bezier((0, 1), .5) == .5', function() {
+      assert.strictEqual(renderer.value('bezier((0, 1), .5)'), '.5');
     });
-    it('bezier((0, 2), 0.5) == 1', function() {
-      assert.strictEqual(renderer.value('bezier((0, 2), 0.5)'), '1');
+    it('bezier((0, 2), .5) == 1', function() {
+      assert.strictEqual(renderer.value('bezier((0, 2), .5)'), '1');
     });
-    it('bezier((0 0 0, 1 1 1), 0.5) == 0.5 0.5 0.5', function() {
-      assert.strictEqual(renderer.value('bezier((0 0 0, 1 1 1), 0.5)'), '0.5 0.5 0.5');
+    it('bezier((0 0 0, 1 1 1), .5) == .5 .5 .5', function() {
+      assert.strictEqual(renderer.value('bezier((0 0 0, 1 1 1), .5)'), '.5 .5 .5');
     });
   });
 });

--- a/test/shared.js
+++ b/test/shared.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var sass = require('node-sass');
+var sass = require('sass');
 var assert = require('assert');
 
 var Renderer = function(head) {
@@ -7,16 +7,18 @@ var Renderer = function(head) {
 }
 
 Renderer.prototype.block = function(input) {
-  var result = sass.renderSync({
-    data: this.head + ' .test{' + input + '}',
-    outputStyle: 'compact',
-    includePaths: [path.resolve(__dirname, '../sass/')],
-  });
-  return result.css.utf8Slice().slice(8, -3);
+  var result = sass.compileString(
+    this.head + '.test{' + input + '}',
+    {
+      style: 'compressed',
+      loadPaths: [path.resolve(__dirname, '../sass/')],
+    },
+  );
+  return result.css.slice(".test".length);
 };
 
 Renderer.prototype.value = function(input) {
-  return this.block('content:' + input).slice(9, -1);
+  return this.block('content:' + input).slice("{content:".length, -("}".length));
 };
 
 var similar = function(result, actual, threshold) {


### PR DESCRIPTION
Hi, thanks for this cool library! I gave this a try because I need to mix colors in Lab color space, and it works great! However, I noticed that I would get some deprecation warnings about using `/` instead of `math.div` when using with the latest version of Sass.

This pull request switches from the now-deprecated Node Sass, to the supported version of Sass, which is [Dart Sass](https://sass-lang.com/dart-sass). The code and associated tests are updated to avoid deprecation warnings with this version of Sass.

I also took the liberty of updating the version number to 0.6.1 and adding an entry to the CHANGES file, in hopes that you might want to cut a new release, so I could use these changes without needing to make my own fork :)

This commit is squashed. The full list of changes is:

- [Update dependencies to latest version](https://github.com/c2d7fa/sass-planifolia/commit/988065e1a0790d6fb455bdeff270b9a50cf4cb2b)
- [Switch to Dart Sass](https://github.com/c2d7fa/sass-planifolia/commit/7d5a975b4f18a938302103d3617758bfc3a38a05)
- [Get rid of deprecation warnings in library itself](https://github.com/c2d7fa/sass-planifolia/commit/8e8a3efba05af0f16e82a9db9cd2ef2bb2344a45)
- [Get rid of deprecation warnings in the test suite](https://github.com/c2d7fa/sass-planifolia/commit/b93645cd3d5a8822aaa06c488092a05f01e3fb5f)
- [Describe changes and bump version number](https://github.com/c2d7fa/sass-planifolia/commit/6428662027a02d622e88cdbd3ecd922fc4559f74)

I hope this PR is useful, but no worries if you don't have time to take a look at it. Let me know if any changes need to be made! :)